### PR TITLE
change PR template to comments

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,7 @@
-What is this change, and why is it needed?
+# What is this change, and why is it needed?
 
-Link to the task for this change in the PR title, if there is one, and make sure your title describes the PR well.
+# Link to the task for this change in the PR title, if there is one, and make sure your title describes the PR well.
 
-If this is a non-trivial UI change, consider adding "Before" and "After" screenshots.
+# If this is a non-trivial UI change, consider adding "Before" and "After" screenshots.
 
-If the steps to test this change are not obvious, include instructions here.
+# If the steps to test this change are not obvious, include instructions here.

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,7 @@
-# What is this change, and why is it needed?
+<!-- What is this change, and why is it needed? -->
 
-# Link to the task for this change in the PR title, if there is one, and make sure your title describes the PR well.
+<!-- Link to the task for this change in the PR title, if there is one, and make sure your title describes the PR well -->
 
-# If this is a non-trivial UI change, consider adding "Before" and "After" screenshots.
+<!-- If this is a non-trivial UI change, consider adding "Before" and "After" screenshots. -->
 
-# If the steps to test this change are not obvious, include instructions here.
+<!-- If the steps to test this change are not obvious, include instructions here. -->


### PR DESCRIPTION
This changes our PR template into comments. Occasionally, we've forgotten to update the description, or left these prompts in with the real description underneath. This makes it so that they can be left in without harming readability for the resulting PR.
