### PR TITLE
Update tj-actions/branch-names to v9.0.0

### DIFF
--- a/workflow-templates/update-main-from-release.yml
+++ b/workflow-templates/update-main-from-release.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v2
       - name: Get branch name
         id: branch-name
-        uses: tj-actions/branch-names@v5.1
+        uses: tj-actions/branch-names@v9.0.0
       - name: Open PR
         uses: repo-sync/pull-request@v2
         with:


### PR DESCRIPTION
This PR updates all usage of `tj-actions/branch-names` to version `v9.0.0` due to a known vulnerability.